### PR TITLE
Add bdofresl2norm parameter for interpreting DOF resolution using L-2 norm

### DIFF
--- a/cbirrt2/cbirrt.cpp
+++ b/cbirrt2/cbirrt.cpp
@@ -1047,7 +1047,7 @@ bool CBirrtPlanner::_CheckCollision(std::vector<dReal>& pQ0, std::vector<dReal>&
   if (!bdofresl2norm) {
     // L-infinity norm
     for (i = 0; i < GetNumDOF(); i++) {
-      int steps = (int)(fabs(pQ1[i] - pQ0[i]) * _jointResolutionInv[i]);
+      int steps = (int) ceil(fabs(pQ1[i] - pQ0[i]) * _jointResolutionInv[i]);
       if (steps > numSteps)
         numSteps = steps;
     }
@@ -1057,7 +1057,9 @@ bool CBirrtPlanner::_CheckCollision(std::vector<dReal>& pQ0, std::vector<dReal>&
     for (i = 0; i < GetNumDOF(); i++) {
       steps_dist2 += pow((pQ1[i] - pQ0[i]) * _jointResolutionInv[i], 2.0);
     }
-    numSteps = (int)sqrt(steps_dist2);
+    numSteps = (int) ceil(sqrt(steps_dist2));
+    if (!(1 <= numSteps))
+      numSteps = 1;
   }
   //cerr << "CheckCollision: number of steps: " << numSteps << endl;
 

--- a/cbirrt2/cbirrt.cpp
+++ b/cbirrt2/cbirrt.cpp
@@ -306,7 +306,7 @@ bool CBirrtPlanner::InitPlan(RobotBasePtr  pbase, PlannerParametersConstPtr ppar
 
 
     bSmoothPath = _parameters->bsmoothpath;
-
+    bdofresl2norm = _parameters->bdofresl2norm;
 
     _pIkSolver = RaveCreateIkSolver(GetEnv(),"GeneralIK");
     _pIkSolver->Init(_pRobot->GetActiveManipulator());
@@ -1044,10 +1044,20 @@ bool CBirrtPlanner::_CheckCollision(std::vector<dReal>& pQ0, std::vector<dReal>&
 
   // compute  the discretization
   int i, numSteps = 1;
-  for (i = 0; i < GetNumDOF(); i++) {
-    int steps = (int)(fabs(pQ1[i] - pQ0[i]) * _jointResolutionInv[i]);
-    if (steps > numSteps)
-      numSteps = steps;
+  if (!bdofresl2norm) {
+    // L-infinity norm
+    for (i = 0; i < GetNumDOF(); i++) {
+      int steps = (int)(fabs(pQ1[i] - pQ0[i]) * _jointResolutionInv[i]);
+      if (steps > numSteps)
+        numSteps = steps;
+    }
+  } else {
+    // L-2 norm
+    dReal steps_dist2 = 0.0;
+    for (i = 0; i < GetNumDOF(); i++) {
+      steps_dist2 += pow((pQ1[i] - pQ0[i]) * _jointResolutionInv[i], 2.0);
+    }
+    numSteps = (int)sqrt(steps_dist2);
   }
   //cerr << "CheckCollision: number of steps: " << numSteps << endl;
 

--- a/cbirrt2/cbirrt.h
+++ b/cbirrt2/cbirrt.h
@@ -92,6 +92,7 @@ public:
         __description = ":Interface Author: Dmitry Berenson\nRRT-based algorithm for planning with end-effector pose constraints described by Task Space Region Chains.\n\n`C++ Documentation <http://automation.berkeley.edu/~berenson/docs/cbirrt/index.html>`_";
         _pActiveNode = NULL;
         _pConnectNode = NULL;
+        bdofresl2norm = false;
 
         //these shouldn't be de-allocated so that multiple calls of this planner are faster
         _pForwardTree = new NodeTree(false);
@@ -301,6 +302,7 @@ private:
     int projectioncalls;
 
     bool bSmoothPath;
+    bool bdofresl2norm;
 
     dReal P_SAMPLE_IK;
 

--- a/cbirrt2/cbirrt.h
+++ b/cbirrt2/cbirrt.h
@@ -133,7 +133,7 @@ public:
     class MakeNext
     {
     public:
-        MakeNext(bool bFromGoal, int numdof, RobotBasePtr  robot, CBirrtPlanner * planner);
+        MakeNext(bool bFromGoal, int numdof, RobotBasePtr  robot, CBirrtPlanner * planner, dReal steplength);
 
         ~MakeNext(){}
 
@@ -154,6 +154,7 @@ public:
         CBirrtPlanner * _planner;
         std::vector<dReal> _lowerLimit;
         std::vector<dReal> _upperLimit;
+        dReal _steplength;
         //variables for tree extension
         dReal* startConfig;
         bool bExtendConnect;

--- a/cbirrt2/cbirrtparameters.h
+++ b/cbirrt2/cbirrtparameters.h
@@ -41,7 +41,7 @@ public:
         smoothingitrs(-1), bsamplingstart(false), bsamplinggoal(false),
         timelimit(-1.0), bProcessing(false),
         bikfastsinglesolution(true), pplannerstate(0),
-        bdofresl2norm(false)
+        steplength(0.05), bdofresl2norm(false)
     {
         _vXMLParameters.push_back("tsrchain");
         _vXMLParameters.push_back("grabbed");
@@ -57,6 +57,7 @@ public:
         _vXMLParameters.push_back("ikguess");
         _vXMLParameters.push_back("bikfastsinglesolution");
         _vXMLParameters.push_back("pplannerstate");
+        _vXMLParameters.push_back("steplength");
         _vXMLParameters.push_back("bdofresl2norm");
 
     }
@@ -83,6 +84,7 @@ public:
 
     enum PlannerState * pplannerstate;
 
+    dReal steplength;
     bool bdofresl2norm; ///< use the L2 norm (instead of the default L-infinity norm) for dof resolutions
 
 protected:
@@ -160,6 +162,7 @@ protected:
         uli = (unsigned long int)pplannerstate;
         O << "<pplannerstate>" << uli << "</pplannerstate>" << endl;
 
+        O << "<steplength>" << steplength << "</steplength>" << endl;
         O << "<bdofresl2norm>" << bdofresl2norm << "</bdofresl2norm>" << endl;
 
         O.precision(old_precision);
@@ -192,6 +195,7 @@ protected:
                        name == "ikguess" ||
                        name == "bikfastsinglesolution" ||
                        name == "pplannerstate" ||
+                       name == "steplength" ||
                        name == "bdofresl2norm");
 
         return bProcessing ? PE_Support : PE_Pass;
@@ -297,6 +301,10 @@ protected:
                 unsigned long int uli;
                 _ss >> uli;
                 pplannerstate = (enum PlannerState *)uli;
+            }
+            else if( stricmp(name.c_str(), "steplength") == 0 )
+            {
+                _ss >> steplength;
             }
             else if( stricmp(name.c_str(), "bdofresl2norm") == 0 )
             {

--- a/cbirrt2/cbirrtparameters.h
+++ b/cbirrt2/cbirrtparameters.h
@@ -40,7 +40,8 @@ public:
         bgrabbed(false), Psample(0), bsmoothpath(true),
         smoothingitrs(-1), bsamplingstart(false), bsamplinggoal(false),
         timelimit(-1.0), bProcessing(false),
-        bikfastsinglesolution(true), pplannerstate(0)
+        bikfastsinglesolution(true), pplannerstate(0),
+        bdofresl2norm(false)
     {
         _vXMLParameters.push_back("tsrchain");
         _vXMLParameters.push_back("grabbed");
@@ -56,6 +57,7 @@ public:
         _vXMLParameters.push_back("ikguess");
         _vXMLParameters.push_back("bikfastsinglesolution");
         _vXMLParameters.push_back("pplannerstate");
+        _vXMLParameters.push_back("bdofresl2norm");
 
     }
     bool bgrabbed; ///< are we grabbing an object?
@@ -80,6 +82,8 @@ public:
     bool bikfastsinglesolution; ///< an optional parameter which chooses between using a single solution from IKFast or using multiple solutions (default is true = single solution)
 
     enum PlannerState * pplannerstate;
+
+    bool bdofresl2norm; ///< use the L2 norm (instead of the default L-infinity norm) for dof resolutions
 
 protected:
     bool bProcessing;
@@ -156,6 +160,8 @@ protected:
         uli = (unsigned long int)pplannerstate;
         O << "<pplannerstate>" << uli << "</pplannerstate>" << endl;
 
+        O << "<bdofresl2norm>" << bdofresl2norm << "</bdofresl2norm>" << endl;
+
         O.precision(old_precision);
         return !!O;
     }
@@ -185,7 +191,8 @@ protected:
                        name == "supportpolyy" || 
                        name == "ikguess" ||
                        name == "bikfastsinglesolution" ||
-                       name == "pplannerstate");
+                       name == "pplannerstate" ||
+                       name == "bdofresl2norm");
 
         return bProcessing ? PE_Support : PE_Pass;
     }
@@ -290,6 +297,10 @@ protected:
                 unsigned long int uli;
                 _ss >> uli;
                 pplannerstate = (enum PlannerState *)uli;
+            }
+            else if( stricmp(name.c_str(), "bdofresl2norm") == 0 )
+            {
+                _ss >> bdofresl2norm;
             }
             else
             {

--- a/cbirrt2/cbirrtproblem.cpp
+++ b/cbirrt2/cbirrtproblem.cpp
@@ -812,6 +812,10 @@ int CBirrtProblem::RunCBirrt(ostream& sout, istream& sinput)
         {
                sinput >> params->bikfastsinglesolution;
         }
+        else if( stricmp(cmd.c_str(), "bdofresl2norm") == 0)
+        {
+               sinput >> params->bdofresl2norm;
+        }
         else if( stricmp(cmd.c_str(), "planinnewthread") == 0)
         {
                sinput >> bPlanInNewThread;

--- a/cbirrt2/cbirrtproblem.cpp
+++ b/cbirrt2/cbirrtproblem.cpp
@@ -812,6 +812,10 @@ int CBirrtProblem::RunCBirrt(ostream& sout, istream& sinput)
         {
                sinput >> params->bikfastsinglesolution;
         }
+        else if( stricmp(cmd.c_str(), "steplength") == 0)
+        {
+            sinput >> params->steplength;
+        }
         else if( stricmp(cmd.c_str(), "bdofresl2norm") == 0)
         {
                sinput >> params->bdofresl2norm;


### PR DESCRIPTION
The [current logic in CBiRRT](https://github.com/personalrobotics/comps/blob/09f5621be4297900efd4ef8836e9fed0d0530130/cbirrt2/cbirrt.cpp#L1045) interprets the robot's DOF resolutions as defining an L-infinity norm -- that is, a segment between collision-checked points A and B need not be sub-divided if B is within an axis-aligned n-orthotope centered around A with side half-extents equal to the DOF resolutions.  This PR adds a new parameter, `bdofresl2norm` (in keeping with the CBiRRT parameter naming scheme): a boolean flag which interprests DOF resolutions using the L-2 norm.  In this case, the shape is now an axis-aligned hyperellipse, with radii equal to the DOF resolutions.  The new parameter defaults to `False`, preserving the old behaviour.  For a given DOF resolutions setting, turning this flag on will tend to increase the number of collision checks required, since the planner is effectively no longer permitted to move each joint by a full resolution unit simultaneously.